### PR TITLE
Improved stringification

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,9 +87,9 @@ module.exports = function(file, package_options) {
 
 			compiled = output.css; 
 			if (textMode || package_options.textMode) {
-	            compiled = "module.exports = \"" + compiled.replace(/'/g, "\\'").replace(/"/g, '\\"') + "\";";
+	            compiled = "module.exports = " + JSON.stringify(compiled) + ";";
 			} else {
-				compiled = func_start + "var css = \"" + compiled.replace(/'/g, "\\'").replace(/"/g, '\\"') + "\";" + func_end;
+				compiled = func_start + "var css = " + JSON.stringify(compiled) + ";" + func_end;
 			}
 
 			self.push(compiled);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-lessify",
-  "version": "0.0.9b",
+  "version": "0.0.10b",
   "description": "LESS precompiler and CSS plugin for Browserify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is a bug in the current version where any backslashes, e.g. `content: '\e807';` are stripped from the compiled CSS. This PR fixes that. It also bumps the version number.