### PR TITLE
should return immediately if error

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function(file, package_options) {
 					msg += ": \"" + e.extract + "\"";
 				}
 
-				done(new Error(msg, file, e.line));
+				return done(new Error(msg, file, e.line));
 			}
 
 			compiled = output.css; 


### PR DESCRIPTION
Hi, thanks for the plugin, it is useful!

in the `end` function, in the callback of `less.render()`, it should return immediately if the callback `done` is called, otherwise it will still keep going down and throws an `TypeError: Cannot read property 'css' of undefined` when executing `compiled = output.css` cuz `output` is `undefined`.

The output will sort of confuses user and break watchify or other watch as well.