### PR TITLE
Improve compile options handling and css source maps workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "frost-node-lessify",
-  "version": "0.1.1-1",
+  "name": "node-lessify",
+  "version": "0.1.1",
   "description": "LESS precompiler and CSS plugin for Browserify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
1. Improved ability to pass options to the transform plugin, and the less compiler plugins.
This allows us to effectively choose to compress the css output or not.

2. Add ability to generate a pseudo-file name for the generated STYLE element, so that we can differentiate them in the browser debugger (tested in Chrome)

From: 
![image](https://cloud.githubusercontent.com/assets/182644/12903542/853abd8c-cf1c-11e5-92dc-1bc9bb296496.png)

To: 
![image](https://cloud.githubusercontent.com/assets/182644/12903725/062872c6-cf1e-11e5-9705-d8ea3a4183d6.png)

