### PR TITLE
Patch 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ module.exports = function (file, transformOptions) {
 		myDirName = path.dirname(file);
 
 	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
-	compileOptions.paths = [].concat(compileOptions.paths || [".", myDirName]);
+	compileOptions.paths = [].concat(compileOptions.paths || [], [".", myDirName]);
 
 	return through(write, end);
 

--- a/index.js
+++ b/index.js
@@ -63,9 +63,8 @@ module.exports = function (file, transformOptions) {
 	var buffer = "",
 		myDirName = path.dirname(file);
 
-	var compileOptions = assign({}, curTransformOptions.compileOptions || {}, {
-		paths: [".", myDirName] // override the "paths" property
-	});
+	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
+	compileOptions.paths = [].concat(compileOptions.paths || [".", myDirName]);
 
 	return through(write, end);
 


### PR DESCRIPTION
don't override paths but extend them. this allows you to use a configuration like this

```
"browserify": {
  "transform": [
    [
      "babelify"
    ],
    [
      "node-lessify",
      {
        "compileOptions": {
          "paths": "node_modules"
        }
      }
    ]
  ]
}
```

and in your code simply refer to module names like this

```
@import 'bootstrap/less/variables.less'
```
