### PR TITLE
Watchify error events & documentation for global events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-node-lessify 
+node-lessify
 ============
 Version 0.1.4
 
@@ -55,9 +55,9 @@ LESS allows one to ```@import``` other LESS files. This module synchronously imp
 See the dummy app in the [test directory](/test) for an example of this in action.
 
 ### Append Less file source URL
-As a workaround to LESS source map issues (e.g. css style lines not referring to the correct LESS file), we can output 
- only the source LESS file name for each require() call of a LESS file. This will at least allow us to distinguish 
- STYLE elements. 
+As a workaround to LESS source map issues (e.g. css style lines not referring to the correct LESS file), we can output
+ only the source LESS file name for each require() call of a LESS file. This will at least allow us to distinguish
+ STYLE elements.
 
 ### Plugins
 You can pass a `plugins` argument to get less plugins like [autoprefix](https://www.npmjs.com/package/less-plugin-autoprefix):
@@ -70,11 +70,29 @@ For example (from [test.js](test/test.js)):
 	var b = browserify(sampleLESS);
 	b.transform(lessify, {
 		compileOptions: {
-			plugins: [autoprefix] 
+			plugins: [autoprefix]
 		}
 	});
 
 Note: This does not currently work via `package.json` arguments, since the plugins need to be required separately, but we're working on it.
+
+### Global Paths
+Pass a `globalPaths` option to append search paths to `less.render`.  These paths will be searched for any `@import` calls.
+
+	var b = browserify(sampleLESS);
+	b.transform(lessify, {
+		globalPaths: {
+			paths: [`${__dirname}/myproject/src/globals`],
+		}
+	});
+
+So we can now just do simple includes in any of our less files
+
+`src/my/really/long/path/file.less`:
+
+	@import colors.less; // Will look for myproject/src/globals/colors.less
+
+
 
 ## Changes
 **v0.1.3, v0.1.4**: Added badges

--- a/README.md
+++ b/README.md
@@ -81,9 +81,7 @@ Pass a `globalPaths` option to append search paths to `less.render`.  These path
 
 	var b = browserify(sampleLESS);
 	b.transform(lessify, {
-		globalPaths: {
-			paths: [`${__dirname}/myproject/src/globals`],
-		}
+		globalPaths: [`${__dirname}/myproject/src/globals`],
 	});
 
 So we can now just do simple includes in any of our less files

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 node-lessify
 ============
-Version 0.1.4
+Version 0.1.5
 
 [![Build Status](https://travis-ci.org/wilson428/node-lessify.png)](https://travis-ci.org/wilson428/node-lessify)
 [![Dependency Status](https://david-dm.org/wilson428/node-lessify.svg)](https://david-dm.org/wilson428/node-lessify)
@@ -43,14 +43,17 @@ LESS allows one to ```@import``` other LESS files. This module synchronously imp
 
 ## Options
 
+### Compile Options
+
+
 ### Text Mode
 [As requested](https://github.com/wilson428/node-lessify/issues/1), it is now possible to ask the transformation not to auto-append the css but merely to compile it into a string and assign it to a variable. This is accomplished by adding a `package.json` file in the directory from which browserify is run with the following properties:
 
-    "browserify": {
-        "transform": [
-            [ "node-lessify", {"textMode": true } ]
-        ]
-    }
+		"browserify": {
+				"transform": [
+						[ "node-lessify", {"textMode": true } ]
+				]
+		}
 
 See the dummy app in the [test directory](/test) for an example of this in action.
 
@@ -76,12 +79,14 @@ For example (from [test.js](test/test.js)):
 
 Note: This does not currently work via `package.json` arguments, since the plugins need to be required separately, but we're working on it.
 
-### Global Paths
-Pass a `globalPaths` option to append search paths to `less.render`.  These paths will be searched for any `@import` calls.
+### Paths
+Pass a `paths` option to compileOptions to append search paths to `less.render`.  These paths will be searched for any `@import` calls.
 
 	var b = browserify(sampleLESS);
 	b.transform(lessify, {
-		globalPaths: [`${__dirname}/myproject/src/globals`],
+		compileOptions: {
+			globalPaths: [`${__dirname}/myproject/src/globals`],
+		}
 	});
 
 So we can now just do simple includes in any of our less files
@@ -93,6 +98,12 @@ So we can now just do simple includes in any of our less files
 
 
 ## Changes
+
+**v0.1.5**:
+	- Added support for (global) path specification (thx @relay-delivery)
+	- Stopped overriding paths for more robust `@includes` (thx @lordvlad)
+	- Improved Watchify support for error handling.
+
 **v0.1.3, v0.1.4**: Added badges
 
 **v0.1.2**: Updated dependencies

--- a/index.js
+++ b/index.js
@@ -108,13 +108,13 @@ module.exports = function (file, transformOptions) {
 				if (err) {
 					var msg = err.message;
 					if (err.line) {
-						msg += "on " + err.line;
+						msg += " on " + err.line;
 					}
 					if (err.column) {
 						msg += ":" + err.column;
 					}
 					if (err.extract) {
-						msg += "\n \"" + err.extract + "\"";
+						msg += "\n" + err.extract + "\n";
 					}
 
 					done(new Error(msg, file, err.line));

--- a/index.js
+++ b/index.js
@@ -84,13 +84,13 @@ module.exports = function (file, transformOptions) {
 				if (err) {
 					var msg = err.message;
 					if (err.line) {
-						msg += ", line " + err.line;
+						msg += "on " + err.line;
 					}
 					if (err.column) {
-						msg += ", column " + err.column;
+						msg += ":" + err.column;
 					}
 					if (err.extract) {
-						msg += ": \"" + err.extract + "\"";
+						msg += "\n \"" + err.extract + "\"";
 					}
 
 					return done(new Error(msg, file, err.line));

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function (file, transformOptions) {
 		myDirName = path.dirname(file);
 
 	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
-	compileOptions.paths = [].concat(compileOptions.paths || [".", myDirName]);
+	compileOptions.paths = [].concat(compileOptions.paths || [], [".", myDirName]);
 
 	return through(write, end);
 

--- a/index.js
+++ b/index.js
@@ -64,9 +64,8 @@ module.exports = function (file, transformOptions) {
 	var buffer = "",
 		myDirName = path.dirname(file);
 
-	var compileOptions = assign({}, curTransformOptions.compileOptions || {}, {
-		paths: [".", myDirName] // override the "paths" property
-	});
+	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
+	compileOptions.paths = [].concat(compileOptions.paths || [".", myDirName]);
 
 	return through(write, end);
 

--- a/index.js
+++ b/index.js
@@ -67,6 +67,12 @@ module.exports = function (file, transformOptions) {
 	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
 	compileOptions.paths = [].concat(compileOptions.paths || [], [".", myDirName]);
 
+	if (transformOptions.globalPaths) {
+		transformOptions.globalPaths.forEach(function(path) {
+			compileOptions.paths.push(path);
+		});
+	}
+
 	return through(write, end);
 
 	function write(chunk, enc, next) {

--- a/index.js
+++ b/index.js
@@ -67,12 +67,6 @@ module.exports = function (file, transformOptions) {
 	var compileOptions = assign({}, curTransformOptions.compileOptions || {});
 	compileOptions.paths = [].concat(compileOptions.paths || [], [".", myDirName]);
 
-	if (transformOptions.globalPaths) {
-		transformOptions.globalPaths.forEach(function(path) {
-			compileOptions.paths.push(path);
-		});
-	}
-
 	return through(write, end);
 
 	function write(chunk, enc, next) {


### PR DESCRIPTION
Was running into issues with Watchify not updating files after a less error, as described [here](https://github.com/substack/watchify/issues/64).
-  Added appropriate event for watchify error recovery
- Made the error outputs easier to read (IMO, can change)
- Brought in changes from @lordvlad in #25 
- Brought in documentation updates from @zivester in #24 (but removed added option, since it accomplishes the same thing as adding to `paths` in `compileOptions)

I'd be happy to join as a maintainer if you'd let me.

Thanks,
David